### PR TITLE
Fix enum name.

### DIFF
--- a/src/frequency.rs
+++ b/src/frequency.rs
@@ -66,7 +66,7 @@ impl ClockSpeeds {
 
     fn get_pll_speed(rcc: &Rcc) -> u32 {
         let hse_div = match rcc.cfgr.read().pllxtpre(){
-            rcc::cfgr::PllxtpreR::Nodiv => 1,
+            rcc::cfgr::PllxtpreR::Div1 => 1,
             rcc::cfgr::PllxtpreR::Div2 => 2,
         };
 


### PR DESCRIPTION
I got this compilation error:
> error: no associated item named `Nodiv` found for type `stm32f103xx::rcc::cfgr::PllxtpreR` in the current scope
  --> src/frequency.rs:69:13
   |
69 |             rcc::cfgr::PllxtpreR::Nodiv => 1,
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> error: aborting due to previous error
